### PR TITLE
fix: validation extra day

### DIFF
--- a/__tests__/unit/app.eventFlow.test.ts
+++ b/__tests__/unit/app.eventFlow.test.ts
@@ -186,12 +186,10 @@ describe('handlePostConditionEntity', () => {
     const result = await handlePostConditionEntity(conditionCreditor as unknown as EntityCondition);
 
     // Assert
-    expect(databaseManager.saveCondition).toHaveBeenCalledWith(
-      expect.objectContaining({
-        ...conditionCreditor,
-        creDtTm: nowDateTime,
-      }),
-    );
+    expect(databaseManager.saveCondition).toHaveBeenCalledWith({
+      ...conditionCreditor,
+      creDtTm: nowDateTime,
+    });
 
     expect(databaseManager.saveGovernedAsCreditorByEdge).toHaveBeenCalledWith('cond123', 'account456', conditionCreditor);
     expect(result).toEqual({

--- a/src/utils/condition-validation.ts
+++ b/src/utils/condition-validation.ts
@@ -76,6 +76,10 @@ export const validateAndParseExpirationDate = (dateStr?: string): DateValidation
 
   const parsedDate = parseDate(dateStr);
 
+  if (parsedDate !== dateStr) {
+    return { isValid: false, dateStr: new Date().toISOString(), message: 'Expiration time date provided was invalid.' };
+  }
+
   if (!parsedDate) {
     return { isValid: false, dateStr: new Date().toISOString(), message: 'Expiration time date provided was invalid.' };
   }


### PR DESCRIPTION
# SPDX-License-Identifier: Apache-2.0

## What did we change?
Validate time date for expiring conditions

## Why are we doing this?
To ensure that the supplied date by the user is correct

## How was it tested?
- [x] Locally
- [ ] Development Environment
- [x] Not needed, changes very basic
- [x] Husky successfully run
- [ ] Unit tests passing and Documentation done
