### PR TITLE
fix: Bump frms-coe-lib version to 5.0.0-rc.5

### DIFF
--- a/__tests__/unit/app.report.test.ts
+++ b/__tests__/unit/app.report.test.ts
@@ -54,7 +54,7 @@ describe('handleGetReportRequestByMsgId', () => {
     const msgid = 'test-msg-id';
     const result = await handleGetReportRequestByMsgId(msgid);
 
-    expect(databaseManager.getReportByMessageId).toHaveBeenCalledWith('transactions', msgid);
+    expect(databaseManager.getReportByMessageId).toHaveBeenCalledWith(msgid);
     expect(unwrap).toHaveBeenCalledWith([mockReport]);
     expect(result).toBe(mockReport);
     expect(loggerService.log).toHaveBeenCalledWith(`Started handling get request by message id the message id is ${msgid}`);
@@ -68,7 +68,7 @@ describe('handleGetReportRequestByMsgId', () => {
     const msgid = 'test-msg-id';
     await expect(handleGetReportRequestByMsgId(msgid)).rejects.toThrow(errorMessage);
 
-    expect(databaseManager.getReportByMessageId).toHaveBeenCalledWith('transactions', msgid);
+    expect(databaseManager.getReportByMessageId).toHaveBeenCalledWith(msgid);
     expect(loggerService.log).toHaveBeenCalledWith(
       `Failed fetching report from database service with error message: ${errorMessage}`,
       'handleGetReportRequestByMsgId()',

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@fastify/swagger": "^8.8.0",
         "@fastify/swagger-ui": "^3.0.0",
         "@tazama-lf/auth-lib": "^0.0.9",
-        "@tazama-lf/frms-coe-lib": "^5.0.0-rc.4",
+        "@tazama-lf/frms-coe-lib": "^5.0.0-rc.5",
         "ajv": "^8.16.0",
         "dotenv": "^16.0.3",
         "fastify": "^4.27.0",
@@ -1978,9 +1978,9 @@
       }
     },
     "node_modules/@tazama-lf/frms-coe-lib": {
-      "version": "5.0.0-rc.4",
-      "resolved": "https://npm.pkg.github.com/download/@tazama-lf/frms-coe-lib/5.0.0-rc.4/9df42df29b5f3039428872d49a9b47e056cd77de",
-      "integrity": "sha512-yvf5uI4UU+QVWQtC4LDwGCFuPKVkkLqk4F9ghmENeDS3ybDoV8GulnfBUMqw3BAB+iDkFS3mtz7hR6B4ZdpTVg==",
+      "version": "5.0.0-rc.5",
+      "resolved": "https://npm.pkg.github.com/download/@tazama-lf/frms-coe-lib/5.0.0-rc.5/1a2b89072e3e9a698a09752a86919eef9fe95c45",
+      "integrity": "sha512-T+yaq0bqKeqbbTy9Q+qGzj/Pp7BXXOj+OHmCOs/+7Oo3U2ifYDPh6AEysslqYGxFVBRh39DbadLR1bcHmL6TYQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@elastic/ecs-pino-format": "^1.5.0",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@fastify/swagger": "^8.8.0",
     "@fastify/swagger-ui": "^3.0.0",
     "@tazama-lf/auth-lib": "^0.0.9",
-    "@tazama-lf/frms-coe-lib": "^5.0.0-rc.4",
+    "@tazama-lf/frms-coe-lib": "^5.0.0-rc.5",
     "ajv": "^8.16.0",
     "dotenv": "^16.0.3",
     "fastify": "^4.27.0",

--- a/src/services/report.logic.service.ts
+++ b/src/services/report.logic.service.ts
@@ -8,7 +8,7 @@ export const handleGetReportRequestByMsgId = async (msgid: string): Promise<Repo
   try {
     loggerService.log(`Started handling get request by message id the message id is ${msgid}`);
 
-    const report = (await databaseManager.getReportByMessageId('transactions', msgid)) as Report[][];
+    const report = (await databaseManager.getReportByMessageId(msgid)) as Report[][];
 
     unWrappedReport = unwrap<Report>(report);
   } catch (error) {


### PR DESCRIPTION
# SPDX-License-Identifier: Apache-2.0

## What did we change?
We change the get function of the report to rely on the Arango structure

## Why are we doing this?
To avoid the hard-coded name of the collection passed as an argument

## How was it tested?
- [x] Locally
- [ ] Development Environment
- [ ] Not needed, changes very basic
- [x] Husky successfully run
- [x] Unit tests passing and Documentation done
