### PR TITLE
feat: return 409 conflict for duplicate Tazama data model tables

### DIFF
--- a/__tests__/unit/tcs-config.logic.service.test.ts
+++ b/__tests__/unit/tcs-config.logic.service.test.ts
@@ -5,6 +5,7 @@ import { describe, it, expect, jest, beforeEach } from '@jest/globals';
 jest.mock('../../src', () => ({
   loggerService: {
     log: jest.fn(),
+    warn: jest.fn(),
     error: jest.fn(),
   },
 }));

--- a/__tests__/unit/tcs-config.logic.service.test.ts
+++ b/__tests__/unit/tcs-config.logic.service.test.ts
@@ -35,6 +35,7 @@ jest.mock('../../src/repositories/configuration/tcs.config.repository', () => ({
 
 import * as tcsConfigService from '../../src/services/tcs-config.logic.service';
 import * as tcsConfigRepository from '../../src/repositories/configuration/tcs.config.repository';
+import { HttpException, HttpStatus } from '../../src/utils/error';
 
 describe('TCS Config Logic Service', () => {
   const mockTenantId = 'tenant-123';
@@ -383,6 +384,17 @@ describe('TCS Config Logic Service', () => {
       (tcsConfigRepository.createTazamaDataModelTable as jest.Mock).mockRejectedValue(new Error('Table creation failed'));
 
       await expect(tcsConfigService.handleCreateTazamaDataModelTable('test_table')).rejects.toThrow('Failed to create data model table');
+    });
+
+    it('should propagate a 409 conflict when the table already exists', async () => {
+      (tcsConfigRepository.createTazamaDataModelTable as jest.Mock).mockRejectedValue(
+        new HttpException('Table "test_table" already exists', HttpStatus.CONFLICT),
+      );
+
+      await expect(tcsConfigService.handleCreateTazamaDataModelTable('test_table')).rejects.toMatchObject({
+        message: 'Table "test_table" already exists',
+        status: 409,
+      });
     });
   });
 

--- a/__tests__/unit/tcs.config.repository.test.ts
+++ b/__tests__/unit/tcs.config.repository.test.ts
@@ -1262,6 +1262,20 @@ describe('TCS Config Repository', () => {
   });
 
   describe('createTazamaDataModelTable', () => {
+    it('should check for an existing table before creating it', async () => {
+      mockHandlePostExecuteSqlStatement.mockResolvedValue({
+        rows: [],
+        rowCount: 0,
+      } as never);
+
+      await createTazamaDataModelTable('tazama_model');
+
+      const existsCallArg = (mockHandlePostExecuteSqlStatement as jest.Mock).mock.calls[0][0] as { text: string; values: string[] };
+      expect(existsCallArg.text).toContain('information_schema.tables');
+      expect(existsCallArg.values).toEqual(['tazama_model']);
+      expect(mockHandlePostExecuteSqlStatement).toHaveBeenNthCalledWith(1, expect.anything(), 'event_history');
+    });
+
     it('should create table with safe name', async () => {
       mockHandlePostExecuteSqlStatement.mockResolvedValue({
         rows: [],
@@ -1270,10 +1284,10 @@ describe('TCS Config Repository', () => {
 
       await createTazamaDataModelTable('tazama_model');
 
-      const callArg = (mockHandlePostExecuteSqlStatement as jest.Mock).mock.calls[0][0] as { text: string };
+      const callArg = (mockHandlePostExecuteSqlStatement as jest.Mock).mock.calls[1][0] as { text: string };
       expect(callArg.text).toContain('CREATE TABLE IF NOT EXISTS');
       expect(callArg.text).toContain('tazama_model');
-      expect(mockHandlePostExecuteSqlStatement).toHaveBeenCalledWith(expect.anything(), 'event_history');
+      expect(mockHandlePostExecuteSqlStatement).toHaveBeenNthCalledWith(2, expect.anything(), 'event_history');
     });
 
     it('should include required columns with primary key', async () => {
@@ -1284,11 +1298,24 @@ describe('TCS Config Repository', () => {
 
       await createTazamaDataModelTable('test_model');
 
-      const callArg = (mockHandlePostExecuteSqlStatement as jest.Mock).mock.calls[0][0] as { text: string };
+      const callArg = (mockHandlePostExecuteSqlStatement as jest.Mock).mock.calls[1][0] as { text: string };
       expect(callArg.text).toContain('_key text PRIMARY KEY');
       expect(callArg.text).toContain('data jsonb NOT NULL');
       expect(callArg.text).toContain('tenantId text');
       expect(callArg.text).toContain('creDtTm text');
+    });
+
+    it('should throw a 409 conflict error when the table already exists', async () => {
+      mockHandlePostExecuteSqlStatement.mockResolvedValueOnce({
+        rows: [{ '?column?': 1 }],
+        rowCount: 1,
+      } as never);
+
+      await expect(createTazamaDataModelTable('tazama_model')).rejects.toMatchObject({
+        message: 'Table "tazama_model" already exists',
+        status: 409,
+      });
+      expect(mockHandlePostExecuteSqlStatement).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/__tests__/unit/tcs.config.repository.test.ts
+++ b/__tests__/unit/tcs.config.repository.test.ts
@@ -1285,8 +1285,8 @@ describe('TCS Config Repository', () => {
       await createTazamaDataModelTable('tazama_model');
 
       const callArg = (mockHandlePostExecuteSqlStatement as jest.Mock).mock.calls[1][0] as { text: string };
-      expect(callArg.text).toContain('CREATE TABLE IF NOT EXISTS');
-      expect(callArg.text).toContain('tazama_model');
+      expect(callArg.text).toContain('CREATE TABLE "tazama_model"');
+      expect(callArg.text).not.toContain('IF NOT EXISTS');
       expect(mockHandlePostExecuteSqlStatement).toHaveBeenNthCalledWith(2, expect.anything(), 'event_history');
     });
 
@@ -1316,6 +1316,26 @@ describe('TCS Config Repository', () => {
         status: 409,
       });
       expect(mockHandlePostExecuteSqlStatement).toHaveBeenCalledTimes(1);
+    });
+
+    it('should throw a 409 conflict error when CREATE TABLE races and hits duplicate_table (42P07)', async () => {
+      mockHandlePostExecuteSqlStatement
+        .mockResolvedValueOnce({ rows: [], rowCount: 0 } as never)
+        .mockRejectedValueOnce(Object.assign(new Error('relation "tazama_model" already exists'), { code: '42P07' }));
+
+      await expect(createTazamaDataModelTable('tazama_model')).rejects.toMatchObject({
+        message: 'Table "tazama_model" already exists',
+        status: 409,
+      });
+      expect(mockHandlePostExecuteSqlStatement).toHaveBeenCalledTimes(2);
+    });
+
+    it('should rethrow non-conflict errors from CREATE TABLE unchanged', async () => {
+      mockHandlePostExecuteSqlStatement
+        .mockResolvedValueOnce({ rows: [], rowCount: 0 } as never)
+        .mockRejectedValueOnce(new Error('connection terminated'));
+
+      await expect(createTazamaDataModelTable('tazama_model')).rejects.toThrow('connection terminated');
     });
   });
 

--- a/src/repositories/configuration/tcs.config.repository.ts
+++ b/src/repositories/configuration/tcs.config.repository.ts
@@ -4,6 +4,7 @@ import { ConfigStatus, ContentType, type FieldMapping, type FunctionDefinition, 
 import { handlePostExecuteSqlStatement } from '../../services/database.logic.service';
 import type { ConfigData, ConfigRow } from '../../interface/config.interface';
 import { validateTableName } from '../../utils/enrichment-utils';
+import { HttpException, HttpStatus } from '../../utils/error';
 
 export type { ConfigData, ConfigRow };
 
@@ -519,6 +520,19 @@ export const createTransactionTypeTable = async (transactionType: string): Promi
 export const createTazamaDataModelTable = async (tableName: string): Promise<void> => {
   const safeTableName = tableName.replace(/[^a-zA-Z0-9_]/g, '_');
   validateTableName(safeTableName);
+
+  const existsQuery = `
+    SELECT 1 FROM information_schema.tables WHERE table_schema = 'public' AND table_name = $1;
+  `;
+  const existsResult = await handlePostExecuteSqlStatement(
+    { text: existsQuery, values: [safeTableName] } satisfies PgQueryConfig,
+    'event_history',
+  );
+
+  if (existsResult.rows.length > 0) {
+    throw new HttpException(`Table "${safeTableName}" already exists`, HttpStatus.CONFLICT);
+  }
+
   const query = `
     CREATE TABLE IF NOT EXISTS "${safeTableName}" (
       _key text PRIMARY KEY,

--- a/src/repositories/configuration/tcs.config.repository.ts
+++ b/src/repositories/configuration/tcs.config.repository.ts
@@ -534,7 +534,7 @@ export const createTazamaDataModelTable = async (tableName: string): Promise<voi
   }
 
   const query = `
-    CREATE TABLE IF NOT EXISTS "${safeTableName}" (
+    CREATE TABLE "${safeTableName}" (
       _key text PRIMARY KEY,
       data jsonb NOT NULL,
       tenantId text,
@@ -542,7 +542,15 @@ export const createTazamaDataModelTable = async (tableName: string): Promise<voi
     );
   `;
 
-  await handlePostExecuteSqlStatement({ text: query, values: [] } satisfies PgQueryConfig, 'event_history');
+  try {
+    await handlePostExecuteSqlStatement({ text: query, values: [] } satisfies PgQueryConfig, 'event_history');
+  } catch (error) {
+    const pgError = error as { code?: string };
+    if (pgError.code === '42P07') {
+      throw new HttpException(`Table "${safeTableName}" already exists`, HttpStatus.CONFLICT);
+    }
+    throw error;
+  }
 };
 
 export const updateConfigByStatus = async (id: string, status: string, tenantId: string): Promise<number> => {

--- a/src/services/database.logic.service.ts
+++ b/src/services/database.logic.service.ts
@@ -33,12 +33,18 @@ export const handlePostExecuteSqlStatement = async <T extends QueryResultRow>(
         throw new Error('Specified database was not found.');
     }
   } catch (error) {
-    const errorMessage = error as { message: string };
+    const errorMessage = error as { message: string; code?: string };
     loggerService.log(
       `Failed executing the query from database service with error message: ${errorMessage.message}`,
       'handlePostExecuteSqlStatement()',
     );
-    throw new Error(errorMessage.message);
+    // Preserve the Postgres SQLSTATE (e.g. 42P07 duplicate_table) so callers can
+    // distinguish specific database error conditions instead of matching on message text.
+    const wrappedError = new Error(errorMessage.message) as Error & { code?: string };
+    if (errorMessage.code) {
+      wrappedError.code = errorMessage.code;
+    }
+    throw wrappedError;
   } finally {
     loggerService.log('Completed handling execution of the query from database service');
   }

--- a/src/services/tcs-config.logic.service.ts
+++ b/src/services/tcs-config.logic.service.ts
@@ -213,7 +213,10 @@ export const handleCreateTazamaDataModelTable = async (tableName: string): Promi
 
     loggerService.log(`Successfully created Tazama data model table: ${tableName}`);
   } catch (error) {
-    if (error instanceof HttpException) throw error;
+    if (error instanceof HttpException) {
+      loggerService.warn(`Conflict creating Tazama data model table "${tableName}": ${error.message}`, 'handleCreateTazamaDataModelTable');
+      throw error;
+    }
     const errorMessage = error as { message: string };
     loggerService.error(`Error creating Tazama data model table: ${errorMessage.message}`, 'handleCreateTazamaDataModelTable');
     throw new Error('Failed to create data model table');

--- a/src/services/tcs-config.logic.service.ts
+++ b/src/services/tcs-config.logic.service.ts
@@ -24,6 +24,7 @@ import {
   getRelatedTransactions,
 } from '../repositories/configuration/tcs.config.repository';
 import type { ConfigData, ConfigInput, ConfigResponse } from '../interface/config.interface';
+import { HttpException } from '../utils/error';
 
 export const handlePostConfig = async (config: ConfigInput, tenantId: string): Promise<{ message: string; result: ConfigResponse }> => {
   try {
@@ -212,6 +213,7 @@ export const handleCreateTazamaDataModelTable = async (tableName: string): Promi
 
     loggerService.log(`Successfully created Tazama data model table: ${tableName}`);
   } catch (error) {
+    if (error instanceof HttpException) throw error;
     const errorMessage = error as { message: string };
     loggerService.error(`Error creating Tazama data model table: ${errorMessage.message}`, 'handleCreateTazamaDataModelTable');
     throw new Error('Failed to create data model table');


### PR DESCRIPTION
# SPDX-License-Identifier: Apache-2.0

## What did we change?

Added an existence check before creating a Tazama data model table. If the sanitized table name already exists in the public schema, the repository now throws a `409 Conflict` instead of silently relying on `CREATE TABLE IF NOT EXISTS`.

The service now preserves `HttpException` responses so conflict errors reach callers unchanged. Unit tests were updated for the repository and logic service paths.

## Why are we doing this?

To make duplicate table creation attempts explicit for API consumers. This gives callers a clear conflict response when a Tazama data model table already exists, instead of masking the condition behind a generic success or generic failure path.

## How was it tested?
- [x] Locally
- [x] Development Environment
- [ ] Not needed, changes very basic
- [x] Husky successfully run
- [x] Unit tests passing and Documentation done

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate Tazama data model tables from being created.
  * Added clear HTTP 409 conflict responses when a requested table already exists, including concurrent creation attempts.
  * Preserved relevant database error details while continuing to handle unrelated errors appropriately.
  * Improved error propagation so conflict responses remain consistent across the service.

* **Tests**
  * Expanded coverage for existing-table conflicts, concurrent creation scenarios, required table structure, and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->